### PR TITLE
Fix. If image was clicked in gallery and it was an image that resulted

### DIFF
--- a/IArch/src/com/github/IArch/ImageDetails.java
+++ b/IArch/src/com/github/IArch/ImageDetails.java
@@ -156,7 +156,7 @@ public class ImageDetails extends Activity {
 					datastore.close();
 				} else {
 					//picture clicked had no data attached to it, do something here
-					
+					datastore.close();
 				}
 			} catch (DbxException e) {
 				// TODO Auto-generated catch block


### PR DESCRIPTION
from a crash or from a user copying an image into iArch directory, it
would keep other data on other images from being displayed.
